### PR TITLE
Fix product poster flexbox layout CSS

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -20,7 +20,7 @@ function Home() {
                 price={18.6}
             />
            </div>
-           <div>
+           <div className="product_poster">
            <Product
             title="Buy SONY TV braviea online. get 30% discount!!"
                 image="https://m.media-amazon.com/images/I/81t9bFDmxBS._AC_UY327_FMwebp_QL65_.jpg"

--- a/src/css/Home.css
+++ b/src/css/Home.css
@@ -8,6 +8,7 @@
 }
 .product_poster{
     display:flex;
-    margin-left:50px;
-    margin-right:50px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: 10px 25px;
 }

--- a/src/css/Product.css
+++ b/src/css/Product.css
@@ -1,19 +1,25 @@
-.product{
+.product {
     /* border:5px solid red; */
     display:flex;
     flex-direction:column;
+    justify-content: space-between;
+    box-sizing: border-box;
     box-shadow: 0.75em 0.75em 1em;
     transition: 0.3s;
+    min-width: 300px;
      width: 35%;
-     height: 100%;
+     height: inherit;
     border-radius: 5px;
+    margin: 15px 25px;
 }
 .product > img{
     max-height:200px;
-    width:100%;
     object-fit:contain;
-    margin-left:15%;
+    margin: 20px auto;
     /* border:5px solid blue; */
-    width:50%
+    width:50%;
+}
 
+.productInfo {
+    padding: 0px 10px;
 }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #2  

I came across this issue and had some suggestions on how to improve the layout of the product poster class and the product component. I set the product poster class set to justify content to the center, but` justify: space-between` is another valid option. (Both behaviors appear on amazon's website, depending on which view you are on.)

<img width="1206" alt="Screen Shot 2021-11-12 at 11 26 15 AM" src="https://user-images.githubusercontent.com/84106309/141492267-3e641afc-24ba-4cf9-9f68-11b898c45fc0.png">

